### PR TITLE
WebSocket-Plugin 2025/03/02版対応

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,5 +1,8 @@
 console.log("background.js");
 
+let ext_runtime;
+let ext_pageAction
+
 //ChromeとFirefoxでruntime切替
 if(typeof browser !== 'undefined'){
 	ext_runtime = browser.runtime;
@@ -13,24 +16,25 @@ ext_runtime.onMessage.addListener(handleMessage);
 
 
 //ブラウザからローカルの棒読みちゃん連携プラグインにデータを渡す
-function boyomi(text) {
-	var delim = "<bouyomi>";
-	var speed = -1; // 速度50-200。-1を指定すると本体設定
-	var pitch = -1; // ピッチ50-200。-1を指定すると本体設定
-	var volume = -1; // ボリューム0-100。-1を指定すると本体設定
-	var type = 0; // 声質(0.本体設定/1.女性1/2.女性2/3.男性1/4.男性2/5.中性/6.ロボット/7.機械1/8.機械2)
+function boyomi(talktext) {
+	// 50002から55000に変更
+	var socket = new WebSocket('ws://localhost:55000/');
 
-
-	// 設定を区切りでつないで送信文字列を作る。
-	var sends = "" + speed + delim + pitch + delim + volume + delim + type + delim + text;
-
-	// 棒読みちゃんに送信　ポートは50002です。
-	var socket = new WebSocket('ws://localhost:50002/');
-	socket.onopen = function() {
-		socket.send(sends);
-	}
+	// 読み上げリクエスト
+	socket.onopen = function (event) {
+		// 読み上げコマンド
+		var talkData = {
+			command: "talk",
+			speed: -1,    // 速度50-200。-1を指定すると本体設定
+			pitch: -1,    // ピッチ50-200。-1を指定すると本体設定
+			volume: -1,   // ボリューム0-100。-1を指定すると本体設定
+			voiceType: 0,  // 声質(0.本体設定/1.女性1/2.女性2/3.男性1/4.男性2/5.中性/6.ロボット/7.機械1/8.機械2)
+			text: talktext
+		};
+		// JSON文字列に変換して送信
+		socket.send(JSON.stringify(talkData));
+	};
 }
-
 
 
 function handleMessage(request, sender, sendResponse) {

--- a/src/content.js
+++ b/src/content.js
@@ -16,10 +16,17 @@ var speak_on_activate = true;
 
 
 /* function */
-function extension_boyomi(readtext){
-	var sending = ext_runtime.sendMessage({
-		readtext: readtext
-	});
+function extension_boyomi(readtext, retryCount = 0) {
+    ext_runtime.sendMessage({ readtext: readtext })
+        .catch((e) => {
+            console.error("sendMessage error:", e);
+			// manifest v3では、service workerはアイドル状態になると自動で停止するため、最大3回リトライするようにしている
+            if (retryCount < 2) { 
+                setTimeout(() => {
+                    extension_boyomi(readtext, retryCount + 1);
+                }, 500); // 0.5秒後に再試行
+            }
+        });
 }
 
 function start_obserb(){

--- a/src/content.js
+++ b/src/content.js
@@ -1,18 +1,21 @@
 console.log('content.js');
 /* define */
 
+let ext_runtime;
+let ext_storage;
+
 //外部プラグインを使用するかのチェックボックスのID checkedが入っていたら棒読みちゃん連携プラグインにデータを渡す
-var str_option_input_external_id = 'highchat_comment__util_read_external';
+let str_option_input_external_id = 'highchat_comment__util_read_external';
 
 //外部プラグインについての説明文　外部プラグインがブラウザに導入されていたら非表示にする。
-var str_option_guide_external_id = 'highchat_comment__util_read_external_guide';
+let str_option_guide_external_id = 'highchat_comment__util_read_external_guide';
 
 // 外部プラグインに渡すテキストの監視対象htmlID
 // 監視対象に変化があったら（MutationObserverが検知したら）内容物のテキストを棒読みちゃん連携プラグインにデータを渡す
-var observe_target_id = 'ext_readtext';
+let observe_target_id = 'ext_readtext';
 
 // オプション値
-var speak_on_activate = true;
+let speak_on_activate = true;
 
 
 /* function */

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,17 +2,12 @@
   "name": "HighChat2Boyomi Transfer",
   "version": "2.0.0",
   "manifest_version": 3,
-  "browser_specific_settings":{
-    "gecko": {
-      "id": "{551f9090-146e-4e3e-8ae1-825e2a2c08ff}"
-    }
-  },
   "description": "配信チャットのコメントデータを棒読みちゃんにWebsocketプラグイン経由で転送します。",
   "icons": {
     "48":"icon.png"
   },
   "background": {
-    "scripts": ["background.js"]
+    "service_worker": "background.js"
   },
   "options_ui": {
     "page": "options.html"

--- a/src/manifest_Firefox.json
+++ b/src/manifest_Firefox.json
@@ -2,12 +2,17 @@
   "name": "HighChat2Boyomi Transfer",
   "version": "2.0.0",
   "manifest_version": 3,
+  "browser_specific_settings":{
+    "gecko": {
+      "id": "{551f9090-146e-4e3e-8ae1-825e2a2c08ff}"
+    }
+  },
   "description": "配信チャットのコメントデータを棒読みちゃんにWebsocketプラグイン経由で転送します。",
   "icons": {
     "48":"icon.png"
   },
   "background": {
-    "service_worker": "background.js"
+    "scripts": ["background.js"]
   },
   "options_ui": {
     "page": "options.html"

--- a/src/options.html
+++ b/src/options.html
@@ -1,15 +1,20 @@
 <!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="utf-8">
-    <title>OPTION</title>
-  </head>
-  <body>
+<html lang="ja">
 
-    <h1>OPTION</h1>
+<head>
+  <meta charset="utf-8">
+  <title>OPTION</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
 
-<label><input type="checkbox" class="option_input option_checkbox" value="1" name="speak_on_activate" id="speak_on_activate">プラグイン起動時・無効時に発声する</label><br/>
+<body>
+
+  <h1>OPTION</h1>
+
+  <label><input type="checkbox" class="option_input option_checkbox" value="1" name="speak_on_activate"
+      id="speak_on_activate">プラグイン起動時・無効時に発声する</label><br />
 
   <script src="options.js"></script>
 </body>
+
 </html>

--- a/src/options.js
+++ b/src/options.js
@@ -1,3 +1,6 @@
+let ext_runtime;
+let ext_storage;
+
 if(typeof browser !== 'undefined'){
 	ext_runtime = browser.runtime;
 	ext_storage = browser.storage.local


### PR DESCRIPTION
background.js
棒読みちゃん用のWebSocket受付プラグインのデフォルトのポート55000番になっていたので変更しました。
JavaScriptからプラグインへ喋らせる方法がJSON形式での送信に変わっていたので変更しました。

content.js
manifest v3では、service workerはアイドル状態になると自動で停止するため、
function extension_boyomiを最大3回リトライするように変更してして棒読みちゃんに頑張って読んでもらえるようにしました。

manifest.json
firefox用の方の拡張機能のデバッグの仕方がよくわからなかったため、chrome系列の方しか確認できませんでした。
そのためmanifest_firefox.jsonという形になったままでした。

そのほかの部分はVSCodeで整形したり赤くなってるところ変えたらずれました。ごめんなさい。